### PR TITLE
add option to include extra files to pandoc input

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,15 @@
 					"default": 750,
 					"description": "The minimum amount of time (in milliseconds) to wait after a pandoc subprocess exits before starting a new one."
 				},
+				"pandocMarkdownPreview.extraPandocInputFiles": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "Path of file to include."
+					},
+					"default": [],
+					"description": "Extra input files to include at the beginning of the buffer passed to pandoc."
+				},
 				"pandocMarkdownPreview.extraPandocArguments": {
 					"type": "string",
 					"default": "",

--- a/src/preview_panel.ts
+++ b/src/preview_panel.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import {exec, ChildProcess, ExecOptions} from 'child_process';
 
 export default class PreviewPanel /* implements vscode.Disposable */ {
@@ -108,6 +109,14 @@ export default class PreviewPanel /* implements vscode.Disposable */ {
 				this.panel.webview.html = stdout;
 			}
 		});
+		for (let inputFile of config.extraPandocInputFiles) {
+			if (path.isAbsolute(inputFile)) {
+				this.subprocess.stdin.write(fs.readFileSync(inputFile));
+			} else {
+				let cwd = path.dirname(this.editor.document.uri.fsPath);
+				this.subprocess.stdin.write(fs.readFileSync(path.join(cwd,inputFile))); 
+			}
+		}
 		this.subprocess.stdin.write(this.editor.document.getText());
 		this.subprocess.stdin.end();
 	}


### PR DESCRIPTION
Adds a setting `extraPandocInputFiles` which is a list of strings consisting of relative or absolute file paths on the local system.

Upon preview, these files are read in the order listed and inserted into the `stdin` stream before the current buffer, whereupon the stream is parsed by pandoc.

I use this to include a collection of LaTeX macros shared across multiple markdown files. For this use case it is essential to pass the macros before parsing (as opposed to using a pandoc filter) because pandoc expands them upon parsing.

However, this feature would be useful for including any collection of shared input files.